### PR TITLE
Install Python Extras

### DIFF
--- a/.github/workflows/cd.terraform.yaml
+++ b/.github/workflows/cd.terraform.yaml
@@ -32,12 +32,14 @@ jobs:
         password: ${{ secrets.ECR_TOKEN }}
     steps:
     - uses: actions/checkout@v4
+    - name: Terraform Version
+      run: terraform version
+    - name: Terraform Check
+      run: terraform fmt --check --recursive --diff ./terraform
     - uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/gh-aws-read
         aws-region: us-west-2
-    - name: Terraform Version
-      run: terraform version
     - name: Init
       run: ci tf init
     - name: Plan
@@ -78,12 +80,14 @@ jobs:
         password: ${{ secrets.ECR_TOKEN }}
     steps:
     - uses: actions/checkout@v4
+    - name: Terraform Version
+      run: terraform version
+    - name: Terraform Check
+      run: terraform fmt --check --recursive --diff ./terraform
     - uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/gh-aws-read
         aws-region: us-west-2
-    - name: Terraform Version
-      run: terraform version
     - name: Init
       run: ci tf init
     - name: Plan

--- a/.github/workflows/ci.python.yaml
+++ b/.github/workflows/ci.python.yaml
@@ -14,6 +14,10 @@ on: # yamllint disable-line
         required: false
         type: boolean
         default: true
+      include_extras:
+        required: false
+        type: boolean
+        default: true
 
 # https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services
 permissions:
@@ -39,7 +43,7 @@ jobs:
         cache: poetry
     - name: Poetry Dependencies
       run: |
-        poetry install
+        poetry install ${{ inputs.include_extras  && '--all-extras' || '' }}
         poetry env info
     # https://github.com/aws-actions/configure-aws-credentials
     - uses: aws-actions/configure-aws-credentials@v4


### PR DESCRIPTION
This PR adds optional support for installing extra modules when running python CI. This is needed for projects where additional, optional dependencies are needed for testing.
