### PR TITLE
Fix Docsify CD

### DIFF
--- a/.github/workflows/cd.docsify.yaml
+++ b/.github/workflows/cd.docsify.yaml
@@ -57,6 +57,7 @@ jobs:
         role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/gh-pipper # yamllint disable-line
         aws-region: us-west-2
     - name: Pipper Dependencies
+      if: inputs.has_code_modules
       run: poetry run task pipper_update_all
     - name: Install Docsify
       if: inputs.install_docsify


### PR DESCRIPTION
This PR adjusts the docsify CD step to skip installing all pipper dependencies when not needed for code generation.
