### PR TITLE
Adds CodeArtifact CD workflow

### DIFF
--- a/.github/workflows/cd.code-artifact.spec.md
+++ b/.github/workflows/cd.code-artifact.spec.md
@@ -1,0 +1,138 @@
+# CD Code Artifact
+
+## Overview
+
+Publishes Python packages to **AWS CodeArtifact** for use in other repositories.
+CodeArtifact is the org's new standard for internal Python package distribution,
+superseding the Pipper S3-backed registry. This workflow is the CodeArtifact
+equivalent of `cd.pipper-uv.yaml` and uses the same `uv`-based toolchain.
+
+---
+
+## Requirements
+
+1. The workflow must accept `devel` and `prod` boolean inputs (both default `false`)
+   that control which CodeArtifact repository the package is published to.
+2. The workflow must accept a `python_version` string input (default `"3.14"`) to
+   control the Python interpreter used for the build.
+3. The workflow must accept an `install_pipper` boolean input (default `true`). When
+   `true`, the workflow runs `uv run task pipper_update_all` before building, so
+   callers that still depend on Pipper packages during the build can install them.
+4. The workflow must authenticate to AWS using OIDC, assuming the `gh-code-artifact`
+   IAM role constructed from the `AWS_ACCOUNT_ID` secret.
+5. The workflow must build the Python distribution with `uv build`.
+6. When `devel` is `true`, the workflow must publish to the `camber-python-devel`
+   CodeArtifact repository in the `camber` domain.
+7. When `prod` is `true`, the workflow must publish to the `camber-python`
+   CodeArtifact repository in the `camber` domain.
+8. Publishing must use `uv publish` with a short-lived CodeArtifact authorization
+   token obtained via `aws codeartifact get-authorization-token`. The repository
+   endpoint must be resolved via `aws codeartifact get-repository-endpoint`.
+
+---
+
+## Acceptance Criteria
+
+- Given a calling repo with a valid `pyproject.toml`, when the workflow runs with
+  `devel: true`, the package version is visible in the `camber-python-devel`
+  CodeArtifact repository.
+- Given a calling repo with a valid `pyproject.toml`, when the workflow runs with
+  `prod: true`, the package version is visible in the `camber-python` CodeArtifact
+  repository.
+- Given `install_pipper: false`, no `uv run task pipper_update_all` step executes.
+- Given `install_pipper: true`, the Pipper dependencies step runs before `uv build`.
+- When both `devel` and `prod` are `false`, no package is published (build-only run).
+
+---
+
+## Out of Scope
+
+- Migration tooling from Pipper to CodeArtifact.
+- Multi-domain CodeArtifact support (only the `camber` domain is in scope).
+- Non-Python artifact types.
+- Creating or managing the `gh-code-artifact` IAM role — this is an AWS
+  infrastructure prerequisite that must be provisioned before the workflow is usable.
+
+---
+
+## Testing Strategy
+
+GitHub Actions reusable workflows cannot be unit tested in isolation. Validation for
+this workflow uses two levels:
+
+1. **YAML lint**: `yamllint .` must pass locally before any push. The `ci.yaml.yaml`
+   workflow enforces this automatically on PR.
+2. **Integration smoke test**: A calling repo invokes the workflow with `devel: true`
+   against a test branch. Successful completion is verified by confirming the package
+   version appears in `camber-python-devel` in CodeArtifact.
+
+---
+
+## Implementation Notes
+
+### Implementation Decisions
+
+- **Direct publish, no Taskipy tasks**: Unlike `cd.pipper-uv.yaml`, which delegates
+  to caller-defined Taskipy tasks (`pipper_bundle`, `pipper_publish`, etc.), this
+  workflow handles all publish steps natively. CodeArtifact requires a short-lived
+  auth token and a computed endpoint URL — these are infrastructure concerns that
+  belong in the workflow, not in every caller's `Taskfile`. This also removes the
+  requirement for callers to define any CA-specific tasks.
+- **Token + endpoint per publish step**: The auth token and repository endpoint are
+  resolved inline within each conditional publish step rather than in shared env
+  variables. This keeps each step self-contained and avoids exposing the token in the
+  job environment for longer than necessary.
+- **`uv publish --publish-url "${ENDPOINT}"`**: The endpoint returned by
+  `aws codeartifact get-repository-endpoint` is the full upload URL for
+  `uv publish`. Do **not** append `/legacy/` — that suffix is PyPI.org-specific
+  and returns 404 on CodeArtifact.
+- **`install_pipper` retained**: Some repos still depend on Pipper packages during
+  the build phase (e.g., internal libraries not yet migrated to CodeArtifact). The
+  `install_pipper` input was kept with a default of `true` to mirror
+  `cd.pipper-uv.yaml` and avoid breaking callers that migrate incrementally.
+- **`shared` input dropped**: Pipper's `shared` publish target has no CodeArtifact
+  equivalent at this time. It was intentionally omitted.
+- **Delete-before-publish for devel**: A "Delete existing version from CodeArtifact
+  (devel)" step runs before each devel publish, removing any previously uploaded
+  version from `camber-python-devel`. This allows repeated PR workflow runs against
+  the same package version to succeed without manual cleanup. The delete uses
+  `|| true` so that first-time publishes (where the version does not yet exist)
+  remain a no-op rather than a failure.
+- **Pre-flight version check for prod**: A "Check for existing version in
+  CodeArtifact (prod)" step runs before the prod publish step. If the version
+  already exists in `camber-python`, the step exits with a human-readable message
+  instructing the developer to bump the version in `pyproject.toml` before merging.
+  This surfaces the conflict before any upload traffic and prevents silent
+  overwrites in production.
+- **Package name normalisation**: Both steps derive the package name from
+  `pyproject.toml` via `tomllib` (stdlib, Python 3.11+) and replace underscores
+  with hyphens to match PyPI/CodeArtifact normalisation. The version is read via
+  `uv version --short`.
+
+### Patterns and Conventions Introduced
+
+- This workflow establishes the org pattern for CodeArtifact publishing: OIDC via
+  `gh-code-artifact`, `uv build`, then token/endpoint resolution per target repo.
+- The `camber` domain and repo names (`camber-python-devel`, `camber-python`) are
+  hardcoded as org-wide constants. Do not parameterise these unless the org adopts
+  multiple domains or a per-team repo structure.
+- **CodeArtifact token before `uv sync`**: AWS credentials must be configured
+  and a CodeArtifact token written to `UV_INDEX_CODE_ARTIFACT_PASSWORD` (via
+  `$GITHUB_ENV`) *before* `uv sync` runs. Any workflow that calls `uv sync` in
+  a repo with a `[[tool.uv.index]] name = "code-artifact"` entry must follow
+  this ordering. All `gh-*` roles carry the required read permissions.
+
+### Testing Approach
+
+- YAML lint validated with `uvx yamllint .github/workflows/cd.code-artifact.yaml` —
+  zero violations.
+- End-to-end validation requires an integration smoke test from a calling repository
+  (see Testing Strategy above).
+
+### Future Interpretation Guidance
+
+- The `gh-code-artifact` IAM role is a hard prerequisite. The workflow will fail at
+  the `configure-aws-credentials` step until this role exists in the target AWS
+  account with CodeArtifact publish permissions attached.
+- If the org migrates pipper dependencies to CodeArtifact, the `install_pipper` input
+  and its associated step can be removed once all callers have migrated.

--- a/.github/workflows/cd.code-artifact.yaml
+++ b/.github/workflows/cd.code-artifact.yaml
@@ -1,0 +1,149 @@
+on: # yamllint disable-line
+  workflow_call:
+    inputs:
+      devel:
+        required: false
+        type: boolean
+        default: false
+      prod:
+        required: false
+        type: boolean
+        default: false
+      python_version:
+        required: false
+        type: string
+        default: "3.14"
+      install_pipper:
+        required: false
+        type: boolean
+        default: true
+      include_extras:
+        required: false
+        type: boolean
+        default: true
+
+# https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services
+permissions:
+  # This is required for AWS OIDC credential access.
+  id-token: write
+  # This is required for actions/checkout.
+  contents: read
+
+jobs:
+  ca_publish:
+    runs-on: ubuntu-latest
+    steps:
+    # https://github.com/actions/checkout
+    - uses: actions/checkout@v6
+    # https://github.com/actions/setup-python
+    - uses: actions/setup-python@v6
+      with:
+        python-version: ${{ inputs.python_version }}
+    # https://github.com/astral-sh/setup-uv
+    - name: Install uv
+      uses: astral-sh/setup-uv@v7
+      with:
+        enable-cache: true
+    # https://github.com/aws-actions/configure-aws-credentials
+    - uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/gh-code-artifact # yamllint disable-line
+        aws-region: us-west-2
+    - name: Configure CodeArtifact
+      env:
+        AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
+      run: |
+        TOKEN=$(aws codeartifact get-authorization-token \
+          --domain camber \
+          --domain-owner "$AWS_ACCOUNT_ID" \
+          --query authorizationToken \
+          --output text)
+        echo "UV_INDEX_CODE_ARTIFACT_USERNAME=aws" >> "$GITHUB_ENV"
+        echo "UV_INDEX_CODE_ARTIFACT_PASSWORD=$TOKEN" >> "$GITHUB_ENV"
+    - name: Install Dependencies
+      run: |
+        uv sync ${{ inputs.include_extras && '--all-extras' || '' }}
+        uv python list
+    - name: Pipper Dependencies
+      if: inputs.install_pipper
+      run: uv run task pipper_update_all
+    - name: Build
+      run: uv build
+    - name: Delete existing version from CodeArtifact (devel)
+      if: inputs.devel
+      env:
+        AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
+      run: |
+        VERSION=$(uv version --short)
+        PACKAGE=$(
+          python3 -c \
+            "import tomllib; d=tomllib.load(open('pyproject.toml','rb')); \
+             print(d['project']['name'].replace('_','-'))"
+        )
+        aws codeartifact delete-package-versions \
+          --domain camber \
+          --domain-owner "$AWS_ACCOUNT_ID" \
+          --repository camber-python-devel \
+          --format pypi \
+          --package "$PACKAGE" \
+          --versions "$VERSION" || true
+    - name: Publish to CodeArtifact (devel)
+      if: inputs.devel
+      env:
+        AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
+      run: |
+        TOKEN=$(aws codeartifact get-authorization-token \
+          --domain camber \
+          --domain-owner "$AWS_ACCOUNT_ID" \
+          --query authorizationToken \
+          --output text)
+        ENDPOINT=$(aws codeartifact get-repository-endpoint \
+          --domain camber \
+          --domain-owner "$AWS_ACCOUNT_ID" \
+          --repository camber-python-devel \
+          --format pypi \
+          --query repositoryEndpoint \
+          --output text)
+        uv publish --publish-url "${ENDPOINT}" --username aws --password "$TOKEN"
+    - name: Check for existing version in CodeArtifact (prod)
+      if: inputs.prod
+      env:
+        AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
+      run: |
+        VERSION=$(uv version --short)
+        PACKAGE=$(
+          python3 -c \
+            "import tomllib; d=tomllib.load(open('pyproject.toml','rb')); \
+             print(d['project']['name'].replace('_','-'))"
+        )
+        EXISTING=$(aws codeartifact list-package-versions \
+          --domain camber \
+          --domain-owner "$AWS_ACCOUNT_ID" \
+          --repository camber-python \
+          --format pypi \
+          --package "$PACKAGE" \
+          --query "versions[?version=='$VERSION']" \
+          --output text 2>/dev/null || true)
+        if [ -n "$EXISTING" ]; then
+          echo "Version $VERSION of $PACKAGE already exists in camber-python (prod)."
+          echo "Bump the version in pyproject.toml before merging."
+          exit 1
+        fi
+    - name: Publish to CodeArtifact (prod)
+      if: inputs.prod
+      env:
+        AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
+      run: |
+        TOKEN=$(aws codeartifact get-authorization-token \
+          --domain camber \
+          --domain-owner "$AWS_ACCOUNT_ID" \
+          --query authorizationToken \
+          --output text)
+        ENDPOINT=$(aws codeartifact get-repository-endpoint \
+          --domain camber \
+          --domain-owner "$AWS_ACCOUNT_ID" \
+          --repository camber-python \
+          --format pypi \
+          --query repositoryEndpoint \
+          --output text)
+        uv publish --publish-url "${ENDPOINT}" --username aws --password "$TOKEN"

--- a/.github/workflows/cd.docsify-uv.yaml
+++ b/.github/workflows/cd.docsify-uv.yaml
@@ -1,30 +1,24 @@
+name: docsify
+
 on: # yamllint disable-line
   workflow_call:
     inputs:
       devel:
-        required: false
         type: boolean
         default: false
       prod:
-        required: false
         type: boolean
         default: false
       python_version:
         required: false
         type: string
         default: "3.14"
-      shared:
-        required: false
-        type: boolean
-        default: false
-      install_pipper:
-        required: false
-        type: boolean
-        default: false
-      include_extras:
-        required: false
+      install_docsify:
         type: boolean
         default: true
+      has_code_modules:
+        type: boolean
+        default: false
 
 # https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services
 permissions:
@@ -34,8 +28,10 @@ permissions:
   contents: read
 
 jobs:
-  pipper_publish:
+  collect_docs:
     runs-on: ubuntu-latest
+    outputs:
+      zipped_docs_name: ${{ steps.docsify.outputs.filename }}
     steps:
     # https://github.com/actions/checkout
     - uses: actions/checkout@v6
@@ -62,26 +58,44 @@ jobs:
           --domain-owner "$AWS_ACCOUNT_ID" \
           --query authorizationToken \
           --output text)
+        ENDPOINT=$(aws codeartifact get-repository-endpoint \
+          --domain camber \
+          --domain-owner "$AWS_ACCOUNT_ID" \
+          --repository camber-python \
+          --format pypi \
+          --query repositoryEndpoint \
+          --output text)
         echo "UV_INDEX_CODE_ARTIFACT_USERNAME=aws" >> "$GITHUB_ENV"
         echo "UV_INDEX_CODE_ARTIFACT_PASSWORD=$TOKEN" >> "$GITHUB_ENV"
+        INDEX_URL="https://aws:${TOKEN}@${ENDPOINT#https://}simple/"
+        echo "CA_INDEX_URL=${INDEX_URL}" >> "$GITHUB_ENV"
     - name: Install Dependencies
+      if: inputs.has_code_modules
       run: |
-        uv sync ${{ inputs.include_extras && '--all-extras' || '' }}
+        uv sync --all-extras
         uv python list
-    - name: Pipper Dependencies
-      if: inputs.install_pipper
-      run: uv run task pipper_update_all
-    - name: Pipper Bundle
-      run: uv run task pipper_bundle
-    - name: Pipper Publish Devel
-      if: inputs.devel
-      run: uv run task pipper_publish_devel
-    - name: Pipper Shared Publish Devel
-      if: inputs.devel && inputs.shared
-      run: uv run task pipper_shared_publish_devel
-    - name: Pipper Publish Prod
-      if: inputs.prod
-      run: uv run task pipper_publish
-    - name: Pipper Shared Publish Prod
-      if: inputs.prod && inputs.shared
-      run: uv run task pipper_shared_publish
+    - name: Install Docsify
+      if: inputs.install_docsify
+      run: uv pip install docsifier --index-url "$CA_INDEX_URL"
+    - name: Docsify
+      id: docsify
+      run: |
+        uv run docsifier collect .
+        ZIPPED_DOCS_NAME=`ls *.__docs__.zip`
+        echo "filename=${ZIPPED_DOCS_NAME}" >> "${GITHUB_OUTPUT}"
+    # https://github.com/actions/upload-artifact
+    - name: Store Zipped Docs
+      uses: actions/upload-artifact@v4
+      with:
+        name: docsified
+        path: ${{ steps.docsify.outputs.filename }}
+  upload_docs:
+    needs: [collect_docs]
+    uses: ./.github/workflows/cd.artifacts.yaml
+    secrets: inherit
+    with:
+      artifact_id: docsified
+      path: ${{ needs.collect_docs.outputs.zipped_docs_name }}
+      s3_path: __docs__/${{ needs.collect_docs.outputs.zipped_docs_name }}
+      devel: ${{ inputs.devel }}
+      prod: ${{ inputs.prod }}

--- a/.github/workflows/ci.python-check.yaml
+++ b/.github/workflows/ci.python-check.yaml
@@ -1,3 +1,4 @@
+# yamllint disable rule:line-length
 name: check-python
 
 on: # yamllint disable-line
@@ -22,6 +23,10 @@ on: # yamllint disable-line
         required: false
         type: boolean
         default: true
+      report_coverage:
+        required: false
+        type: boolean
+        default: false
 
 # https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services
 permissions:
@@ -29,6 +34,8 @@ permissions:
   id-token: write
   # This is required for actions/checkout.
   contents: read
+  # This is required for posting coverage comments on PRs.
+  pull-requests: write
 
 jobs:
   python_check:
@@ -43,15 +50,26 @@ jobs:
     # https://github.com/astral-sh/setup-uv
     - name: Install uv
       uses: astral-sh/setup-uv@v7
+    # https://github.com/aws-actions/configure-aws-credentials
+    - uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/gh-standard
+        aws-region: us-west-2
+    - name: Configure CodeArtifact
+      env:
+        AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
+      run: |
+        TOKEN=$(aws codeartifact get-authorization-token \
+          --domain camber \
+          --domain-owner "$AWS_ACCOUNT_ID" \
+          --query authorizationToken \
+          --output text)
+        echo "UV_INDEX_CODE_ARTIFACT_USERNAME=aws" >> "$GITHUB_ENV"
+        echo "UV_INDEX_CODE_ARTIFACT_PASSWORD=$TOKEN" >> "$GITHUB_ENV"
     - name: Install Dependencies
       run: |
         uv sync ${{ inputs.include_extras && '--all-extras' || '' }}
         uv python list
-    # https://github.com/aws-actions/configure-aws-credentials
-    - uses: aws-actions/configure-aws-credentials@v4
-      with:
-        role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/gh-standard # yamllint disable-line
-        aws-region: us-west-2
     - name: Pipper Dependencies
       if: inputs.install_pipper
       run: uv run task pipper_update_all
@@ -64,3 +82,41 @@ jobs:
     - name: Test
       if: inputs.test
       run: uv run task test
+    - name: Coverage Summary
+      if: inputs.test && github.event_name == 'pull_request'
+      id: coverage
+      run: |
+        SUMMARY=$(uv run coverage report --format=markdown 2>/dev/null || uv run coverage report 2>/dev/null || echo "Coverage report not available.")
+        echo "summary<<EOF" >> "$GITHUB_OUTPUT"
+        echo "$SUMMARY" >> "$GITHUB_OUTPUT"
+        echo "EOF" >> "$GITHUB_OUTPUT"
+    # https://github.com/actions/github-script
+    - name: Coverage Comment
+      if: inputs.test && inputs.report_coverage && github.event_name == 'pull_request'
+      uses: actions/github-script@v7
+      with:
+        github-token: ${{ github.token }}
+        script: |
+          const marker = '<!-- coverage-comment -->';
+          const body = `${marker}\n### Coverage Report\n${{ steps.coverage.outputs.summary }}`;
+          const { data: comments } = await github.rest.issues.listComments({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: context.issue.number,
+          });
+          const existing = comments.find(c => c.body.includes(marker));
+          if (existing) {
+            await github.rest.issues.updateComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: existing.id,
+              body,
+            });
+          } else {
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body,
+            });
+          }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,172 @@
+# AGENTS.md — camber-ops/workflows
+
+## Purpose
+
+This repository contains **reusable GitHub Actions workflows** for the `camber-ops`
+organization. All workflows use the `workflow_call` trigger and are intended to be
+called from other repositories via:
+
+```yaml
+uses: camber-ops/workflows/.github/workflows/<workflow-file>.yaml@main
+```
+
+---
+
+## Repository Structure
+
+```
+.github/workflows/   # All reusable workflow definitions
+.yamllint.yaml       # yamllint configuration used across the org
+```
+
+---
+
+## Workflow Catalog
+
+### CI Workflows
+
+| File | Purpose |
+|------|---------|
+| `ci.python.yaml` | Python quality checks (flake8, pydocstyle, radon, mypy) + tests. Uses **Poetry**. Older standard. |
+| `ci.python-check.yaml` | Python quality checks (ruff, mypy) + tests + coverage comments. Uses **uv**. Newer standard. |
+| `ci.python-gemini.yaml` | Python checks inside the `gemini` ECR container. Modifies `pyproject.toml` for `##CI-ONLY##` deps before running. Uses **Poetry**. |
+| `ci.python-horizon.yaml` | Python checks inside the `horizon` ECR container. Same pattern as gemini. Uses **Poetry**. |
+| `ci.structure.yaml` | Enforces **single commit per PR** using the GitHub REST API. |
+| `ci.yaml.yaml` | Runs `yamllint` against all YAML files. Falls back to fetching `.yamllint.yaml` from this repo if none is present in the caller. |
+
+### CD Workflows
+
+| File | Purpose |
+|------|---------|
+| `cd.pipper.yaml` | Publishes Python packages to the internal **Pipper** registry. Uses **Poetry**. |
+| `cd.pipper-uv.yaml` | Publishes Python packages to the internal **Pipper** registry. Uses **uv**. Newer standard. |
+| `cd.code-artifact.yaml` | Publishes Python packages to **AWS CodeArtifact**. Uses **uv**. Supersedes Pipper for new projects. |
+| `cd.docker.yaml` | Builds and pushes Docker images to ECR (public + private). Uses **Podman** as the Docker runtime. Supports `amd64` (default) and `arm64` targets. |
+| `cd.artifacts.yaml` | Downloads a GitHub Actions artifact and uploads it to S3 (`cbrdata-devel-artifacts` or `cbrdata-prod-artifacts`). |
+| `cd.docsify.yaml` | Runs `docsifier collect` to bundle docs and uploads them to S3 via `cd.artifacts.yaml`. |
+| `cd.lambda.yaml` | Runs a `reviser` shell macro inside the `proxy-hub-prod:reviser-*` ECR container to deploy Lambda functions. |
+| `cd.terraform.yaml` | Runs `terraform fmt --check`, `ci tf plan`, and optionally `ci tf apply` for `devel` and/or `prod` workspaces. Uses the `gemini:ci-terraform-prod` ECR container. |
+
+### Internal Workflow
+
+| File | Purpose |
+|------|---------|
+| `yaml-all.yaml` | Self-check — runs `ci.yaml.yaml` on any YAML change pushed or PR'd to `main` in this repo. |
+
+---
+
+## Key Conventions
+
+### Package Managers
+- **uv** (`ci.python-check.yaml`, `cd.pipper-uv.yaml`) — modern standard for new
+  projects.
+- **Poetry** (`ci.python.yaml`, `cd.pipper.yaml`, container-based workflows) — legacy
+  standard, still in active use.
+- When adding a new Python workflow, prefer **uv** unless the caller indicates that
+  Poetry should be used.
+
+### Internal Package Registry — Pipper
+- Camber uses **Pipper**, an S3-backed internal Python package registry.
+- Bucket: `cbrdata-pipper` (internal packages),
+  `cbrdata-devel-artifacts` / `cbrdata-prod-artifacts` (build artifacts).
+- Callers typically expose `pipper_update`, `pipper_update_all`, `pipper_bundle`,
+  `pipper_publish`, `pipper_publish_devel` as Taskipy tasks.
+- **Pipper is the legacy standard.** New projects should use CodeArtifact instead.
+
+### Package Registry — AWS CodeArtifact
+- CodeArtifact is the modern standard for internal Python package distribution.
+- Domain: `camber`. Devel repo: `camber-python-devel`. Prod repo: `camber-python`.
+- Publishing is handled natively in the workflow via `aws codeartifact` token
+  retrieval and `uv publish` — no Taskipy tasks are required in the caller.
+- Requires the `gh-code-artifact` IAM role to be provisioned in the AWS account.
+
+### AWS Authentication
+- All AWS access uses **OIDC** (no long-lived credentials).
+- Every workflow that needs AWS includes:
+  ```yaml
+  permissions:
+    id-token: write
+    contents: read
+  ```
+- The only secrets expected from callers are `AWS_ACCOUNT_ID` (for role ARNs) and
+  `ECR_TOKEN` (for pulling private ECR container images).
+
+### IAM Roles (all in `arn:aws:iam::<AWS_ACCOUNT_ID>:role/`)
+| Role | Used by |
+|------|---------|
+| `gh-standard` | General-purpose read (Pipper installs in CI) |
+| `gh-pipper` | Publishing to the Pipper registry |
+| `gh-code-artifact` | Publishing to AWS CodeArtifact (`cd.code-artifact.yaml`) |
+| `gh-ecr` | Pushing images to ECR |
+| `gh-artifacts` | Uploading to artifact S3 buckets |
+| `gh-lambda` | Deploying Lambda functions |
+| `gh-aws-read` | Terraform read-only plan |
+| `gh-aws-read-write` | Terraform apply |
+
+### Docker / Container Builds
+- Uses **Podman** aliased to `docker` (not Docker daemon).
+- Linting done with **Hadolint** v2.14.0 via `ci hadolint <target>`.
+- Build/push done via `ci build <mode> <target> --push --podman`.
+- `build_mode` is one of `ci`, `devel`, or `prod`.
+- ARM builds require a custom runner (`ubuntu-arm-custom`); AMD builds use
+  `ubuntu-latest`.
+- `build_target` is a space-separated list of sequential targets.
+
+### Python Quality Tools
+| Toolchain | Linters | Type Checker | Test Runner |
+|-----------|---------|--------------|-------------|
+| uv (modern) | ruff | mypy | pytest via `task test` |
+| Poetry (legacy) | flake8, pydocstyle, radon | mypy | pytest via `task test` |
+
+### Terraform
+- Terraform state is managed per-workspace (`devel`/`prod`).
+- `ci tf <env> plan/apply` is a wrapper CLI available inside the
+  `gemini:ci-terraform-prod` container.
+- `devel`/`prod` inputs accept `"skip"`, `"plan"`, or `"apply"`.
+
+### PR Policy
+- `ci.structure.yaml` enforces **exactly one commit per PR**. Squash/rebase before
+  merging.
+
+### YAML Style
+- `.yamllint.yaml` at the repo root defines org-wide YAML linting rules.
+- Callers that don't have their own `.yamllint.yaml` will inherit this repo's config
+  automatically via `ci.yaml.yaml`.
+- Use `uvx yamllint` command when validation yaml files in this repo.
+
+### Markdown Style
+- Hard line limit of 89 characters where possible for all files in this repo.
+
+---
+
+## Secrets Reference
+
+| Secret | Required By | Description |
+|--------|-------------|-------------|
+| `AWS_ACCOUNT_ID` | All AWS workflows | AWS account ID for role ARN construction |
+| `ECR_TOKEN` | Container-based workflows | Password to pull private ECR images |
+| `GITHUB_TOKEN` | `ci.structure.yaml`, `ci.python-check.yaml` | Implicit GitHub token for API calls and PR comments |
+
+---
+
+## Adding a New Workflow
+
+1. Create `.github/workflows/ci.<name>.yaml` or `cd.<name>.yaml`.
+2. Use `on: workflow_call` as the trigger.
+3. Include the OIDC permissions block if AWS access is needed.
+4. Reference `AWS_ACCOUNT_ID` from secrets (never hardcode account IDs).
+5. Prefer **uv** over Poetry for new Python workflows.
+6. Validate locally with `yamllint .` before pushing.
+
+---
+
+## ECR Image Registry
+
+Private ECR account: `819888084929.dkr.ecr.us-west-2.amazonaws.com`
+
+| Image | Used In |
+|-------|---------|
+| `gemini:gemini-workflows-prod-prerelease` | `ci.python-gemini.yaml` |
+| `gemini:ci-terraform-prod` | `cd.terraform.yaml` |
+| `horizon:horizon-prod-prerelease` | `ci.python-horizon.yaml` |
+| `proxy-hub-prod:reviser-<version>` | `cd.lambda.yaml` |

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # workflows
+
+A collection of re-usable GitHub action workflows for the camber-ops organization.


### PR DESCRIPTION
Introduces a new workflow for publishing Python packages to AWS CodeArtifact,
superseding the Pipper registry for new projects.

This workflow supports publishing to development and production
repositories, handles AWS authentication using OIDC, and builds
packages using uv. It also includes logic to install Pipper
dependencies if needed for incremental migration.

Includes documentation for agents and workflows in the repo.
