### PR TITLE
Fix Toolbelt Initialization

### DIFF
--- a/.github/workflows/cd.artifacts.yaml
+++ b/.github/workflows/cd.artifacts.yaml
@@ -43,7 +43,10 @@ jobs:
           token: ${{ secrets.REPO_READ_PAT }}
           path: .toolbelt
       - name: Load Toolbelt
-        uses: ./.toolbelt
+        run: |
+          chmod -R +x $GITHUB_WORKSPACE/.toolbelt/bin
+          echo "$GITHUB_WORKSPACE/.toolbelt/bin" >> $GITHUB_PATH
+        shell: bash
       - name: AWS CLI
         run: aws --version
       # https://github.com/aws-actions/configure-aws-credentials

--- a/.github/workflows/cd.code-artifact.yaml
+++ b/.github/workflows/cd.code-artifact.yaml
@@ -46,7 +46,10 @@ jobs:
           token: ${{ secrets.REPO_READ_PAT }}
           path: .toolbelt
       - name: Load Toolbelt
-        uses: ./.toolbelt
+        run: |
+          chmod -R +x $GITHUB_WORKSPACE/.toolbelt/bin
+          echo "$GITHUB_WORKSPACE/.toolbelt/bin" >> $GITHUB_PATH
+        shell: bash
       # https://github.com/actions/setup-python
       - uses: actions/setup-python@v6
         with:

--- a/.github/workflows/cd.docker.yaml
+++ b/.github/workflows/cd.docker.yaml
@@ -53,7 +53,10 @@ jobs:
           token: ${{ secrets.REPO_READ_PAT }}
           path: .toolbelt
       - name: Load Toolbelt
-        uses: ./.toolbelt
+        run: |
+          chmod -R +x $GITHUB_WORKSPACE/.toolbelt/bin
+          echo "$GITHUB_WORKSPACE/.toolbelt/bin" >> $GITHUB_PATH
+        shell: bash
       # Poetry must be installed before python setup for caching to work.
       # https://github.com/actions/setup-python/issues/369
       - name: Install Poetry

--- a/.github/workflows/cd.docsify-uv.yaml
+++ b/.github/workflows/cd.docsify-uv.yaml
@@ -44,7 +44,10 @@ jobs:
           token: ${{ secrets.REPO_READ_PAT }}
           path: .toolbelt
       - name: Load Toolbelt
-        uses: ./.toolbelt
+        run: |
+          chmod -R +x $GITHUB_WORKSPACE/.toolbelt/bin
+          echo "$GITHUB_WORKSPACE/.toolbelt/bin" >> $GITHUB_PATH
+        shell: bash
       # https://github.com/actions/setup-python
       - uses: actions/setup-python@v6
         with:

--- a/.github/workflows/cd.docsify.yaml
+++ b/.github/workflows/cd.docsify.yaml
@@ -40,7 +40,10 @@ jobs:
           token: ${{ secrets.REPO_READ_PAT }}
           path: .toolbelt
       - name: Load Toolbelt
-        uses: ./.toolbelt
+        run: |
+          chmod -R +x $GITHUB_WORKSPACE/.toolbelt/bin
+          echo "$GITHUB_WORKSPACE/.toolbelt/bin" >> $GITHUB_PATH
+        shell: bash
       # Poetry must be installed before python setup for caching to work.
       # https://github.com/actions/setup-python/issues/369
       - name: Install Poetry

--- a/.github/workflows/cd.lambda.yaml
+++ b/.github/workflows/cd.lambda.yaml
@@ -45,7 +45,10 @@ jobs:
           token: ${{ secrets.REPO_READ_PAT }}
           path: .toolbelt
       - name: Load Toolbelt
-        uses: ./.toolbelt
+        run: |
+          chmod -R +x $GITHUB_WORKSPACE/.toolbelt/bin
+          echo "$GITHUB_WORKSPACE/.toolbelt/bin" >> $GITHUB_PATH
+        shell: bash
       - uses: actions/cache@v4
         with:
           path: ~/.cache/pip

--- a/.github/workflows/cd.pipper-uv.yaml
+++ b/.github/workflows/cd.pipper-uv.yaml
@@ -50,7 +50,10 @@ jobs:
           token: ${{ secrets.REPO_READ_PAT }}
           path: .toolbelt
       - name: Load Toolbelt
-        uses: ./.toolbelt
+        run: |
+          chmod -R +x $GITHUB_WORKSPACE/.toolbelt/bin
+          echo "$GITHUB_WORKSPACE/.toolbelt/bin" >> $GITHUB_PATH
+        shell: bash
       # https://github.com/actions/setup-python
       - uses: actions/setup-python@v6
         with:

--- a/.github/workflows/cd.pipper.yaml
+++ b/.github/workflows/cd.pipper.yaml
@@ -46,7 +46,10 @@ jobs:
           token: ${{ secrets.REPO_READ_PAT }}
           path: .toolbelt
       - name: Load Toolbelt
-        uses: ./.toolbelt
+        run: |
+          chmod -R +x $GITHUB_WORKSPACE/.toolbelt/bin
+          echo "$GITHUB_WORKSPACE/.toolbelt/bin" >> $GITHUB_PATH
+        shell: bash
       # Poetry must be installed before python setup for caching to work.
       # https://github.com/actions/setup-python/issues/369
       - name: Install Poetry

--- a/.github/workflows/cd.terraform.yaml
+++ b/.github/workflows/cd.terraform.yaml
@@ -36,7 +36,10 @@ jobs:
           token: ${{ secrets.REPO_READ_PAT }}
           path: .toolbelt
       - name: Load Toolbelt
-        uses: ./.toolbelt
+        run: |
+          chmod -R +x $GITHUB_WORKSPACE/.toolbelt/bin
+          echo "$GITHUB_WORKSPACE/.toolbelt/bin" >> $GITHUB_PATH
+        shell: bash
       - uses: hashicorp/setup-terraform@v3
       - name: Terraform Version
         run: terraform version

--- a/.github/workflows/ci.prettier.yaml
+++ b/.github/workflows/ci.prettier.yaml
@@ -22,7 +22,10 @@ jobs:
           token: ${{ secrets.REPO_READ_PAT }}
           path: .toolbelt
       - name: Load Toolbelt
-        uses: ./.toolbelt
+        run: |
+          chmod -R +x $GITHUB_WORKSPACE/.toolbelt/bin
+          echo "$GITHUB_WORKSPACE/.toolbelt/bin" >> $GITHUB_PATH
+        shell: bash
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/ci.python-check.yaml
+++ b/.github/workflows/ci.python-check.yaml
@@ -51,7 +51,10 @@ jobs:
           token: ${{ secrets.REPO_READ_PAT }}
           path: .toolbelt
       - name: Load Toolbelt
-        uses: ./.toolbelt
+        run: |
+          chmod -R +x $GITHUB_WORKSPACE/.toolbelt/bin
+          echo "$GITHUB_WORKSPACE/.toolbelt/bin" >> $GITHUB_PATH
+        shell: bash
       # https://github.com/actions/setup-python
       - uses: actions/setup-python@v6
         with:

--- a/.github/workflows/ci.python-gemini.yaml
+++ b/.github/workflows/ci.python-gemini.yaml
@@ -51,7 +51,10 @@ jobs:
           token: ${{ secrets.REPO_READ_PAT }}
           path: .toolbelt
       - name: Load Toolbelt
-        uses: ./.toolbelt
+        run: |
+          chmod -R +x $GITHUB_WORKSPACE/.toolbelt/bin
+          echo "$GITHUB_WORKSPACE/.toolbelt/bin" >> $GITHUB_PATH
+        shell: bash
       - name: Modify PyProject.toml
         shell: python
         run: |

--- a/.github/workflows/ci.python-horizon.yaml
+++ b/.github/workflows/ci.python-horizon.yaml
@@ -51,7 +51,10 @@ jobs:
           token: ${{ secrets.REPO_READ_PAT }}
           path: .toolbelt
       - name: Load Toolbelt
-        uses: ./.toolbelt
+        run: |
+          chmod -R +x $GITHUB_WORKSPACE/.toolbelt/bin
+          echo "$GITHUB_WORKSPACE/.toolbelt/bin" >> $GITHUB_PATH
+        shell: bash
       - name: Modify PyProject.toml
         shell: python
         run: |

--- a/.github/workflows/ci.python.yaml
+++ b/.github/workflows/ci.python.yaml
@@ -61,7 +61,10 @@ jobs:
           token: ${{ secrets.REPO_READ_PAT }}
           path: .toolbelt
       - name: Load Toolbelt
-        uses: ./.toolbelt
+        run: |
+          chmod -R +x $GITHUB_WORKSPACE/.toolbelt/bin
+          echo "$GITHUB_WORKSPACE/.toolbelt/bin" >> $GITHUB_PATH
+        shell: bash
       # Poetry must be installed before python setup for caching to work.
       # https://github.com/actions/setup-python/issues/369
       - name: Install Poetry

--- a/.github/workflows/ci.yaml.yaml
+++ b/.github/workflows/ci.yaml.yaml
@@ -23,7 +23,10 @@ jobs:
           token: ${{ secrets.REPO_READ_PAT }}
           path: .toolbelt
       - name: Load Toolbelt
-        uses: ./.toolbelt
+        run: |
+          chmod -R +x $GITHUB_WORKSPACE/.toolbelt/bin
+          echo "$GITHUB_WORKSPACE/.toolbelt/bin" >> $GITHUB_PATH
+        shell: bash
       # https://github.com/actions/setup-python
       - uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
Root Cause: uses: ./.toolbelt in a reusable workflow (workflow_call) fails because GitHub Actions pre-fetches and pre-initializes all local composite actions (uses: ./) before any job steps execute. At pre-fetch time, the calling repo (etl-ingest) has no .toolbelt/ in its git tree — it only exists after the "Checkout Toolbelt" step runs. This causes ${{ github.action_path }} to be set to a pre-staged path that GitHub prepared from the (empty) .toolbelt/ context, which lacks bin. The subsequent checkout puts files in $GITHUB_WORKSPACE/.toolbelt/, but the composite action's github.action_path has already been bound to a different staging location.
