### PR TITLE
Upgrade AWS Credentials Action to v6

### DIFF
--- a/.github/workflows/cd.artifacts.yaml
+++ b/.github/workflows/cd.artifacts.yaml
@@ -50,7 +50,7 @@ jobs:
       - name: AWS CLI
         run: aws --version
       # https://github.com/aws-actions/configure-aws-credentials
-      - uses: aws-actions/configure-aws-credentials@v4
+      - uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume:
             arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/gh-artifacts

--- a/.github/workflows/cd.code-artifact.yaml
+++ b/.github/workflows/cd.code-artifact.yaml
@@ -60,7 +60,7 @@ jobs:
         with:
           enable-cache: true
       # https://github.com/aws-actions/configure-aws-credentials
-      - uses: aws-actions/configure-aws-credentials@v4
+      - uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume:
             arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/gh-code-artifact

--- a/.github/workflows/cd.docker.yaml
+++ b/.github/workflows/cd.docker.yaml
@@ -78,7 +78,7 @@ jobs:
       - name: Pip Install
         run: pip install pipper
       # https://github.com/aws-actions/configure-aws-credentials
-      - uses: aws-actions/configure-aws-credentials@v4
+      - uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/gh-ecr
           aws-region: us-west-2
@@ -158,7 +158,7 @@ jobs:
       - name: Pip Install
         run: pip install pipper
       # https://github.com/aws-actions/configure-aws-credentials
-      - uses: aws-actions/configure-aws-credentials@v4
+      - uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/gh-ecr
           aws-region: us-west-2

--- a/.github/workflows/cd.docsify-uv.yaml
+++ b/.github/workflows/cd.docsify-uv.yaml
@@ -58,7 +58,7 @@ jobs:
         with:
           enable-cache: true
       # https://github.com/aws-actions/configure-aws-credentials
-      - uses: aws-actions/configure-aws-credentials@v4
+      - uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume:
             arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/gh-pipper

--- a/.github/workflows/cd.docsify.yaml
+++ b/.github/workflows/cd.docsify.yaml
@@ -65,7 +65,7 @@ jobs:
           poetry run python -m pip install pipper
           poetry env info
       # https://github.com/aws-actions/configure-aws-credentials
-      - uses: aws-actions/configure-aws-credentials@v4
+      - uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume:
             arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/gh-pipper

--- a/.github/workflows/cd.lambda.yaml
+++ b/.github/workflows/cd.lambda.yaml
@@ -58,7 +58,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-
       # https://github.com/aws-actions/configure-aws-credentials
-      - uses: aws-actions/configure-aws-credentials@v4
+      - uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume:
             arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/gh-lambda

--- a/.github/workflows/cd.pipper-uv.yaml
+++ b/.github/workflows/cd.pipper-uv.yaml
@@ -64,7 +64,7 @@ jobs:
         with:
           enable-cache: true
       # https://github.com/aws-actions/configure-aws-credentials
-      - uses: aws-actions/configure-aws-credentials@v4
+      - uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume:
             arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/gh-pipper

--- a/.github/workflows/cd.pipper.yaml
+++ b/.github/workflows/cd.pipper.yaml
@@ -63,7 +63,7 @@ jobs:
           poetry install
           poetry env info
       # https://github.com/aws-actions/configure-aws-credentials
-      - uses: aws-actions/configure-aws-credentials@v4
+      - uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume:
             arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/gh-pipper

--- a/.github/workflows/cd.terraform.yaml
+++ b/.github/workflows/cd.terraform.yaml
@@ -45,7 +45,7 @@ jobs:
         run: terraform version
       - name: Terraform Check
         run: terraform fmt --check --recursive --diff ./terraform
-      - uses: aws-actions/configure-aws-credentials@v4
+      - uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume:
             arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/gh-aws-read
@@ -78,7 +78,7 @@ jobs:
           name: devel-plan-report
           path: devel_plan_report.json
       - if: ${{ inputs.devel == 'apply' }}
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume:
             arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/gh-aws-read-write
@@ -99,7 +99,7 @@ jobs:
         run: terraform version
       - name: Terraform Check
         run: terraform fmt --check --recursive --diff ./terraform
-      - uses: aws-actions/configure-aws-credentials@v4
+      - uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume:
             arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/gh-aws-read
@@ -132,7 +132,7 @@ jobs:
           name: prod-plan-report
           path: prod_plan_report.json
       - if: ${{ inputs.prod == 'apply' }}
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume:
             arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/gh-aws-read-write

--- a/.github/workflows/ci.python-check.yaml
+++ b/.github/workflows/ci.python-check.yaml
@@ -59,7 +59,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
       # https://github.com/aws-actions/configure-aws-credentials
-      - uses: aws-actions/configure-aws-credentials@v4
+      - uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume:
             arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/gh-standard

--- a/.github/workflows/ci.python-gemini.yaml
+++ b/.github/workflows/ci.python-gemini.yaml
@@ -72,7 +72,7 @@ jobs:
           poetry install ${{ inputs.include_extras  && '--all-extras' || '' }}
           poetry env info
       # https://github.com/aws-actions/configure-aws-credentials
-      - uses: aws-actions/configure-aws-credentials@v4
+      - uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume:
             arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/gh-standard

--- a/.github/workflows/ci.python-horizon.yaml
+++ b/.github/workflows/ci.python-horizon.yaml
@@ -72,7 +72,7 @@ jobs:
           poetry install ${{ inputs.include_extras  && '--all-extras' || '' }}
           poetry env info
       # https://github.com/aws-actions/configure-aws-credentials
-      - uses: aws-actions/configure-aws-credentials@v4
+      - uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume:
             arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/gh-standard

--- a/.github/workflows/ci.python.yaml
+++ b/.github/workflows/ci.python.yaml
@@ -79,7 +79,7 @@ jobs:
           poetry install ${{ inputs.include_extras  && '--all-extras' || '' }}
           poetry env info
       # https://github.com/aws-actions/configure-aws-credentials
-      - uses: aws-actions/configure-aws-credentials@v4
+      - uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume:
             arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/gh-standard


### PR DESCRIPTION
- **AWS Action Version Bump** - Upgrade `aws-actions/configure-aws-credentials`
  from v4 to v6 across all CI/CD workflows where needed. The v4 action is
  approaching end-of-life; v6 aligns with the latest supported release to
  maintain compatibility with current AWS authentication mechanisms and avoid
  future deprecation failures in pipelines.
