### PR TITLE
Harden ARM Podman Install

### DIFF
--- a/.github/workflows/cd.docker.yaml
+++ b/.github/workflows/cd.docker.yaml
@@ -166,8 +166,12 @@ jobs:
         run: pipper install --bucket=cbrdata-pipper ci
       - name: Install Podman
         run: |
-          sudo apt-get update
-          sudo apt-get -y install podman
+          # Clear stale package lists before update to avoid transient mirror-sync
+          # errors on ports.ubuntu.com (ARM64). Acquire::Retries=5 retries failed
+          # fetches automatically without needing a shell loop.
+          sudo rm -rf /var/lib/apt/lists/*
+          sudo apt-get -o Acquire::Retries=5 update
+          sudo apt-get -o Acquire::Retries=5 install -y --no-install-recommends podman
           podman --version
       # Alias podman to docker since podman is a drop-in replacement
       - name: Alias Podman to Docker


### PR DESCRIPTION
- **ARM64 CI Reliability** - Transient mirror-sync errors on
  ports.ubuntu.com were causing intermittent ARM64 podman install
  failures. Clearing stale package lists before update, adding
  automatic fetch retries, and reducing package surface area makes
  the install step resilient to these races without manual
  intervention.
