### PR TITLE
fix: install uidmap for ARM Podman builds

### DIFF
--- a/.github/workflows/cd.docker.yaml
+++ b/.github/workflows/cd.docker.yaml
@@ -171,7 +171,7 @@ jobs:
           # fetches automatically without needing a shell loop.
           sudo rm -rf /var/lib/apt/lists/*
           sudo apt-get -o Acquire::Retries=5 update
-          sudo apt-get -o Acquire::Retries=5 install -y --no-install-recommends podman
+          sudo apt-get -o Acquire::Retries=5 install -y --no-install-recommends podman uidmap
           podman --version
       # Alias podman to docker since podman is a drop-in replacement
       - name: Alias Podman to Docker


### PR DESCRIPTION
## Summary
- install `uidmap` alongside Podman in the reusable Docker workflow
- keep the hardened ARM apt retry/no-install-recommends path while restoring `newuidmap` for rootless Podman

## Why
ARM Docker jobs started failing during ECR login with `exec: "newuidmap": executable file not found in $PATH` after the Podman install was hardened with `--no-install-recommends`. `uidmap` provides that helper binary.

## Validation
- `npx prettier --check .github/workflows/cd.docker.yaml`
- `mpx --me check`